### PR TITLE
change getRemote() to match dg rig.

### DIFF
--- a/root/tasks/lib/s3.js
+++ b/root/tasks/lib/s3.js
@@ -45,8 +45,11 @@ var download = async function (Bucket, Key) {
 };
 
 // get a single page of results from S3
-var getRemote = async function (Bucket, Prefix, Marker = null) {
-  var results = await s3.send(new ListObjectsV2Command({ Bucket, Prefix, Marker }));
+var getRemote = async function (Bucket, Prefix, next = undefined) {
+  var input = { Bucket, Prefix };
+  if (next) input.ContinuationToken = next;
+  var command = new ListObjectsV2Command(input);
+  var results = await s3.send(command);
   var items = (results.Contents || []).map(function (obj) {
     return {
       file: obj.Key.replace(/.*\/synced\//, ""),
@@ -55,7 +58,7 @@ var getRemote = async function (Bucket, Prefix, Marker = null) {
       mtime: obj.LastModified,
     };
   }).filter((i) => i.size);
-  var next = results.IsTruncated ? items[items.length - 1].key : null;
+  var next = results.IsTruncated ? results.NextContinuationToken : null;
   return { items, next };
 };
 


### PR DESCRIPTION
Hey there, I was using this code in our interactive rig. Was getting stuck in a do loop when the s3 bucket grew past 1000 items. Porting over the getRemote() code from the s3.js file in the dailygraphics rig fixed the problem. Basically, I don't think the program was correctly getting the next page of 1000 results.